### PR TITLE
AppD Investigation 

### DIFF
--- a/app/src/main/java/com/test/appdagp8/MainApplication.kt
+++ b/app/src/main/java/com/test/appdagp8/MainApplication.kt
@@ -2,25 +2,12 @@ package com.test.appdagp8
 
 import android.app.Application
 import android.util.Log
-import com.appdynamics.eumagent.runtime.AgentConfiguration
-import com.appdynamics.eumagent.runtime.Instrumentation
 
 
 class MainApplication : Application() {
 
     override fun onCreate() {
         super.onCreate()
-        val agentConfiguration = AgentConfiguration.builder()
-            .withContext(this)
-            .withScreenshotsEnabled(false)
-            .withLoggingLevel(Instrumentation.LOGGING_LEVEL_VERBOSE)
-            .withJSAgentInjectionEnabled(false)
-            .withAppKey(APPD_API_KEY)
-            .withCollectorURL(APPD_COLLECTOR_URL)
-            .withCompileTimeInstrumentationCheck(false)
-            .build()
-        Instrumentation.start(agentConfiguration)
-        Log.d("AppD Test", "Application onCreate, AppD initialised and started")
     }
 
     companion object {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     id("com.android.application") version agpVersion apply false
     id("com.android.library") version agpVersion apply false
     id("org.jetbrains.kotlin.android") version "1.8.21" apply false
-    id("com.google.dagger.hilt.android") version "2.44.2" apply false
+    id("com.google.dagger.hilt.android") version "2.46" apply false
     id("adeum") version "23.4.1" apply false
 }
 


### PR DESCRIPTION
## ! This PR does not fix the issue, but explains where the issue is. 

This looks like an issue with `kapt` \ `hilt`.

With the code changes here, you can see that:

1. We removed traces of AppDynamics Android Agent. 
2. We added a separate task, that adds a new class, based on the gradle recipe here (copy-paste): https://github.com/android/gradle-recipes/blob/agp-7.4/Kotlin/appendToProjectClasses/app/build.gradle.kts 
3. We run `./gradlew assembleDebug`. It works the first time (like with appd agent). Following runs are failing, but some are successful. You can investigate the path: `app/build/intermediates/classes/debug/transformDebugClassesWithAsm` and notice that with every run, a new `transformDebugClassesWithAsm` is created in `transformDebugClassesWithAsm/dirs`. The task from hilt I assume called `transformDebugClassesWithAsm` is wrongly processing the input and duplicating files. 

I tried updating to the latest version, `2.46`, without luck. 

As a followup, I did not see any bug or issue raised for `kapt` \ `hilt` regarding this. One needs to be created.

`Workaround:` 
* `clean` before every build
* manually remove `build/intermediates/classes/{build}` before every build. Faster than cleaning every time and seems to be working fine. 

`Additional info:` Why the android agent needs to add new classes even if instrumentation is disabled? 
-> Even if the instrumentation is disabled and classes are not processed, we still need to add a `buildInfo` class during the build that identifies a specific build. This is added very similar to how the interface is added in the gradle recipe. 